### PR TITLE
Remove deprecated global reference

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 declare module '*.md' {


### PR DESCRIPTION
## Summary
- remove outdated reference to `next/types/global` in `next-env.d.ts`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'fs' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68860bada7848330b20e218982c85d23