### PR TITLE
Fix lecture heading regex

### DIFF
--- a/lib/mdx.ts
+++ b/lib/mdx.ts
@@ -5,7 +5,11 @@ import { MDXRemoteSerializeResult } from 'next-mdx-remote'
 
 export async function loadMdx(filePath: string): Promise<MDXRemoteSerializeResult> {
   const source = fs.readFileSync(filePath, 'utf8')
-  return serialize(source)
+  const processed = source.replace(/^(#{1,6})\s*([^#\n]*?)\s*{#([^}]+)}\s*$/gm, (_m, hashes, title, id) => {
+    const level = (hashes as string).length
+    return `<h${level} id="${id}">${(title as string).trim()}</h${level}>`
+  })
+  return serialize(processed)
 }
 
 export function getLectureSlugs(): string[] {


### PR DESCRIPTION
## Summary
- convert markdown headings with `{#id}` suffix into HTML before serialization

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68861521211083309aeaeae7dada1afb